### PR TITLE
Add option to adjust the module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,11 @@ function bundleManifest(filename, opts) {
   function convertPathToModuleName(filepath) {
     // splitting by file system seperator and
     // always using slashes makes it OS agnostic
-    return filepath.split(path.sep).join("/");
+    var moduleName = filepath.split(path.sep).join("/");
+    if (opts.adjustModuleName) {
+      moduleName = opts.adjustModuleName(moduleName);
+    }
+    return moduleName;  
   }
 
   function addPrefix(filepath) {


### PR DESCRIPTION
Sometimes it is necessary to remove parts in the middle of the file path to get a good module name. This allows the caller to specify an option `adjustModuleName` with a function that is called before each file name is transformed into a module name.
